### PR TITLE
Fix typos and HTML comment handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 
 1. **Fork 并克隆仓库**
    ```bash
-   git clone https://github.com/yourusername/ilovelie.git
+   git clone https://github.com/baicai99/ilovelie.git
    cd ilovelie
    ```
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ function initDatabase() {
 
 - 暂无已知问题
 
-如果您发现任何问题，请在 [GitHub Issues](https://github.com/yourusername/ilovelie/issues) 中报告。
+如果您发现任何问题，请在 [GitHub Issues](https://github.com/baicai99/ilovelie/issues) 中报告。
 
 ## 📄 更新日志
 

--- a/src/aiReplacer.ts
+++ b/src/aiReplacer.ts
@@ -401,11 +401,11 @@ export class AIReplacer {
             .replace(/^\/\/+\s*/, '')     // 移除开头的 //
             .replace(/^\/\*+\s*/, '')     // 移除开头的 /*
             .replace(/\s*\*+\/$/, '')     // 移除结尾的 */
-            .replace(/^<!--\s*/, '')      // 秘除开头的 <!--
-            .replace(/\s*-->$/, '')       // 秘除结尾的 -->
+            .replace(/^<!--\s*/, '')      // 移除开头的 <!--
+            .replace(/\s*-->$/, '')       // 移除结尾的 -->
             .replace(/^#+\s*/, '')        // 移除开头的 #
             // 移除中间可能出现的注释符号
-            .replace(/\/\/+/g, '')        // 秼除所有 //
+            .replace(/\/\/+/g, '')        // 移除所有 //
             .replace(/\/\*[\s\S]*?\*\//g, '') // 移除所有 /* */
             .replace(/<!--[\s\S]*?-->/g, '') // 移除所有 <!-- -->
             .trim();
@@ -1141,8 +1141,9 @@ ${numberedComments}
             case 'jsdoc-comment':
                 return 'documentation';
             case 'multi-line-star':
-            case 'html-comment':
                 return 'block';
+            case 'html-comment':
+                return 'html';
             default:
                 return 'line';
         }

--- a/src/dictionaryReplacer.ts
+++ b/src/dictionaryReplacer.ts
@@ -178,11 +178,11 @@ export class DictionaryReplacer {
     private extractCommentContent(commentText: string): string {
         return commentText
             .replace(/^\/\*+/, '')  // 移除 /* 开头
-            .replace(/\*+\/$/, '')  // 秼除*/ 结尾
+            .replace(/\*+\/$/, '')  // 移除 */ 结尾
             .replace(/^\/\/+/, '')  // 移除 // 开头
             .replace(/^\s*\*+/gm, '') // 移除每行开头的 * (全局多行模式)
-            .replace(/<!--/, '')    // 秘移除 HTML 注释开头
-            .replace(/-->/, '')     // 秘移除 HTML 注释结尾
+            .replace(/<!--/, '')    // 移除 HTML 注释开头
+            .replace(/-->/, '')     // 移除 HTML 注释结尾
             .replace(/^#+/, '')     // 移除 # 开头（markdown等）
             .replace(/\n/g, ' ')    // 将换行符替换为空格
             .replace(/\s+/g, ' ')   // 将多个空格合并为一个
@@ -693,8 +693,9 @@ export class DictionaryReplacer {
             case 'jsdoc-comment':
                 return 'documentation';
             case 'multi-line-star':
-            case 'html-comment':
                 return 'block';
+            case 'html-comment':
+                return 'html';
             default:
                 return 'line';
         }

--- a/src/test/commentDetector.test.ts
+++ b/src/test/commentDetector.test.ts
@@ -1,0 +1,16 @@
+import * as assert from 'assert';
+import { CommentDetector } from '../commentDetector';
+
+describe('CommentDetector', () => {
+  const detector = new CommentDetector();
+
+  it('detects html comment format', () => {
+    const format = detector.getCommentFormat('<!-- hello -->', 'html');
+    assert.strictEqual(format, 'html-comment');
+  });
+
+  it('replaces html comment content', () => {
+    const result = detector.replaceCommentContent('<!-- old -->', 'new', 'html');
+    assert.strictEqual(result, '<!-- new -->');
+  });
+});


### PR DESCRIPTION
## Summary
- fix typos in comment cleaning code
- handle HTML comments correctly when mapping formats
- update documentation links
- add tests for CommentDetector

## Testing
- `npm test` *(fails: Cannot find name 'console' due to tsconfig lib issues)*

------
https://chatgpt.com/codex/tasks/task_e_68479e68eab88327a923a11b22813214