### PR TITLE
Fix comment toggle uses file path

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -118,7 +118,7 @@ export class CommandRegistrar {
         const onDidCloseDocument = vscode.workspace.onDidCloseTextDocument((document) => {
             this.commentHider.handleDocumentClose(document);
             // 清理toggle状态
-            this.toggleManager.cleanupDocumentState(document.uri.toString());
+            this.toggleManager.cleanupDocumentState(document.uri.fsPath);
         });
 
         context.subscriptions.push(onDidCloseDocument);
@@ -307,7 +307,7 @@ export class CommandRegistrar {
                 return;
             }
 
-            const documentUri = editor.document.uri.toString();
+            const documentUri = editor.document.uri.fsPath;
 
             // 获取当前文件的历史记录数量
             const records = this.historyManager.getRecordsForFile(documentUri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,8 +35,8 @@ export function activate(context: vscode.ExtensionContext) {
 	historyManager = new HistoryManager();
 	historyManager.initialize(context);
 	commentDetector = new CommentDetector();
-	commentScanner = new CommentScanner();
-	toggleManager = new ToggleManager(historyManager, commentScanner);
+        commentScanner = new CommentScanner();
+        toggleManager = new ToggleManager(historyManager);
 	toggleManager.initialize(context);
 	// 传递toggleManager给需要它的替换器
 	commentReplacer = new CommentReplacer(commentDetector, historyManager, toggleManager);

--- a/src/replacer/aiReplacer.ts
+++ b/src/replacer/aiReplacer.ts
@@ -642,7 +642,7 @@ ${numberedComments}
             });
 
             // 通知toggle manager状态已更新
-            this.toggleManager?.notifyLiesAdded(editor.document.uri.toString());
+            this.toggleManager?.notifyLiesAdded(editor.document.uri.fsPath);
             vscode.window.showInformationMessage('🎉 AI撒谎替换完成！代码注释已被AI完美伪装。');
             console.log(`[AIReplacer] AI单个替换会话保持活跃`);
 
@@ -830,7 +830,7 @@ ${numberedComments}
                 }
             }); const failedCount = results.filter(r => !r.success).length; if (success && replacedCount > 0) {
                 // 通知toggle manager状态已更新
-                this.toggleManager?.notifyLiesAdded(editor.document.uri.toString());
+                this.toggleManager?.notifyLiesAdded(editor.document.uri.fsPath);
                 let message = `🎉 AI批量撒谎完成！成功替换了 ${replacedCount} 个注释`;
                 if (failedCount > 0) {
                     message += `，${failedCount} 个失败`;
@@ -1056,7 +1056,7 @@ ${numberedComments}
                 }
             }); const failedCount = results.filter(r => !r.success).length; if (success && replacedCount > 0) {
                 // 通知toggle manager状态已更新
-                this.toggleManager?.notifyLiesAdded(editor.document.uri.toString());
+                this.toggleManager?.notifyLiesAdded(editor.document.uri.fsPath);
                 let message = `🎉 AI选择性撒谎完成！成功替换了 ${replacedCount} 个注释`;
                 if (failedCount > 0) {
                     message += `，${failedCount} 个失败`;

--- a/src/replacer/commentReplacer.ts
+++ b/src/replacer/commentReplacer.ts
@@ -122,7 +122,7 @@ export class CommentReplacer {
 
                 // 通知状态管理器有新的撒谎记录
                 if (this.toggleManager) {
-                    this.toggleManager.notifyLiesAdded(editor.document.uri.toString());
+                    this.toggleManager.notifyLiesAdded(editor.document.uri.fsPath);
                 }
 
                 vscode.window.showInformationMessage('注释替换成功！你已经成功撒谎了 😈');
@@ -202,7 +202,7 @@ export class CommentReplacer {
 
                 // 通知状态管理器有新的撒谎记录
                 if (this.toggleManager) {
-                    this.toggleManager.notifyLiesAdded(editor.document.uri.toString());
+                    this.toggleManager.notifyLiesAdded(editor.document.uri.fsPath);
                 }
 
                 vscode.window.showInformationMessage('注释替换成功！你已经成功撒谎了 😈');
@@ -324,7 +324,7 @@ export class CommentReplacer {
 
                 // 通知状态管理器有新的撒谎记录
                 if (this.toggleManager) {
-                    this.toggleManager.notifyLiesAdded(editor.document.uri.toString());
+                    this.toggleManager.notifyLiesAdded(editor.document.uri.fsPath);
                 }
 
                 vscode.window.showInformationMessage('注释替换成功！你已经成功撒谎了 😈');

--- a/src/replacer/dictionaryReplacer.ts
+++ b/src/replacer/dictionaryReplacer.ts
@@ -127,7 +127,7 @@ export class DictionaryReplacer {
 
         if (success && totalReplacedCount > 0) {
             // 通知toggle manager状态已更新
-            this.toggleManager?.notifyLiesAdded(editor.document.uri.toString());
+            this.toggleManager?.notifyLiesAdded(editor.document.uri.fsPath);
 
             // 构建详细的完成消息
             let message = `字典替换完成！共替换了 ${totalReplacedCount} 个注释`;
@@ -355,7 +355,7 @@ export class DictionaryReplacer {
             });
         }); if (success && replacedCount > 0) {
             // 通知toggle manager状态已更新
-            this.toggleManager?.notifyLiesAdded(editor.document.uri.toString());
+            this.toggleManager?.notifyLiesAdded(editor.document.uri.fsPath);
             vscode.window.showInformationMessage(
                 `选择性字典替换完成！共替换了 ${replacedCount} 个注释。`
             );
@@ -507,7 +507,7 @@ export class DictionaryReplacer {
 
         if (success && replacedCount > 0) {
             // 通知toggle manager状态已更新
-            this.toggleManager?.notifyLiesAdded(editor.document.uri.toString());
+            this.toggleManager?.notifyLiesAdded(editor.document.uri.fsPath);
 
             // 只有在showMessage为true时才显示消息
             if (showMessage) {
@@ -576,7 +576,7 @@ export class DictionaryReplacer {
             }
         }); if (success) {
             // 通知toggle manager状态已更新
-            this.toggleManager?.notifyLiesAdded(editor.document.uri.toString());
+            this.toggleManager?.notifyLiesAdded(editor.document.uri.fsPath);
             vscode.window.showInformationMessage(
                 `随机替换完成！成功替换了 ${replacedCount} 条注释`
             );
@@ -651,7 +651,7 @@ export class DictionaryReplacer {
                 }
             }); if (success) {
                 // 通知toggle manager状态已更新
-                this.toggleManager?.notifyLiesAdded(editor.document.uri.toString());
+                this.toggleManager?.notifyLiesAdded(editor.document.uri.fsPath);
                 vscode.window.showInformationMessage(
                     `手动替换完成！成功替换了 ${replacedCount} 条注释`
                 );


### PR DESCRIPTION
## Summary
- use file paths consistently in toggle manager
- update all calls to notifyLiesAdded and cleanup state
- add method to refresh document state

## Testing
- `npm test` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847cec4bc808327b0f254526386792f