### PR TITLE
Implement history clearing

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -323,7 +323,7 @@ export class CommandRegistrar {
             );
 
             if (confirm === '确定') {
-                const result = await this.historyManager.clearRecordsForFile(documentUri);
+                const result = this.historyManager.clearRecordsForFile(documentUri);
 
                 if (result.success) {
                     // 更新toggle状态

--- a/src/manager/historyManager.ts
+++ b/src/manager/historyManager.ts
@@ -88,6 +88,19 @@ export class HistoryManager {
     return this.records.filter(r => r.filePath === filePath);
   }
 
+  /**
+   * Clear all records associated with a file.
+   */
+  public clearRecordsForFile(filePath: string): { success: boolean; clearedCount: number } {
+    const before = this.records.length;
+    this.records = this.records.filter(r => r.filePath !== filePath);
+    const cleared = before - this.records.length;
+    if (cleared > 0) {
+      this.save();
+    }
+    return { success: true, clearedCount: cleared };
+  }
+
   /** Remove record by id. */
   public removeRecordById(id: string): boolean {
     const idx = this.records.findIndex(r => r.id === id);

--- a/src/test/historyManager.test.ts
+++ b/src/test/historyManager.test.ts
@@ -25,3 +25,23 @@ suite('HistoryManager duplicate cleanup', () => {
     assert.strictEqual(records[0].versionNumber, 3);
   });
 });
+
+suite('HistoryManager clear records', () => {
+  const manager = new HistoryManager();
+  const uri1 = 'file:///tmp/a.ts';
+  const uri2 = 'file:///tmp/b.ts';
+  const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1));
+
+  test('clearRecordsForFile removes records for specific file', async () => {
+    const r1 = manager.createHistoryRecord(uri1, 'o', 'n', range, 'manual-replace');
+    await manager.addRecord(r1);
+    const r2 = manager.createHistoryRecord(uri2, 'o', 'n2', range, 'manual-replace');
+    await manager.addRecord(r2);
+
+    const result = manager.clearRecordsForFile(uri1);
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.clearedCount, 1);
+    assert.strictEqual(manager.getRecordsForFile(uri1).length, 0);
+    assert.strictEqual(manager.getRecordsForFile(uri2).length, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `clearRecordsForFile` to history manager
- call the new method in command handler
- test clearing history records

## Testing
- `npm test` *(fails: Cannot find module 'vscode' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6847dae99758832785a6f1d826e0db58