### PR TITLE
Add setup script for test dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,9 @@
    ```
 
 2. **安装依赖**
+   运行脚本安装所有开发依赖（包括 `@types/vscode`、`@types/node`、`@types/mocha` 等测试库），以便在全新环境中顺利运行测试：
    ```bash
-   npm install
+   bash ./scripts/setup-tests.sh
    ```
 
 3. **启动开发模式**

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -14,8 +14,10 @@ npm install -g vsce
 - ✅ `CHANGELOG.md` - 包含版本更新信息
 - ✅ `LICENSE` - 包含许可证信息
 
-### 3. 运行完整测试
+### 3. 安装依赖并运行完整测试
+在全新的环境下，需要先安装开发依赖（其中包含 `@types/vscode`、`@types/node`、`@types/mocha` 等测试库），可以直接执行脚本：
 ```bash
+bash ./scripts/setup-tests.sh
 npm test
 ```
 

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Install development dependencies required for testing
+set -e
+npm ci


### PR DESCRIPTION
## Summary
- add setup-tests.sh to install dev dependencies
- document running the setup script in CONTRIBUTING and PUBLISH guides

## Testing
- `bash scripts/setup-tests.sh` *(fails: MaxListenersExceededWarning)*
- `npm test` *(fails to compile: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6847daeb342c832796131d4a95fabb90