### PR TITLE
Add document snapshot support for sessions

### DIFF
--- a/src/replacer/aiReplacer.ts
+++ b/src/replacer/aiReplacer.ts
@@ -571,7 +571,7 @@ ${numberedComments}
 
         // 启动新的撒谎会话
         const filePath = editor.document.uri.fsPath;
-        const sessionId = this.historyManager.startLieSession(filePath);
+        const sessionId = this.historyManager.startLieSession(filePath, editor.document.getText());
         console.log(`[AIReplacer] 开始新的AI单个替换会话: ${sessionId}`);
 
         try {
@@ -669,7 +669,7 @@ ${numberedComments}
 
         // 启动新的撒谎会话
         const filePath = editor.document.uri.fsPath;
-        const sessionId = this.historyManager.startLieSession(filePath);
+        const sessionId = this.historyManager.startLieSession(filePath, editor.document.getText());
         console.log(`[AIReplacer] 开始新的AI撒谎会话: ${sessionId}`);
 
         // 使用CommentScanner检测所有注释
@@ -870,7 +870,7 @@ ${numberedComments}
 
         // 启动新的撒谎会话
         const filePath = editor.document.uri.fsPath;
-        const sessionId = this.historyManager.startLieSession(filePath);
+        const sessionId = this.historyManager.startLieSession(filePath, editor.document.getText());
         console.log(`[AIReplacer] 开始新的AI选择性撒谎会话: ${sessionId}`);
 
         // 使用CommentScanner检测所有注释

--- a/src/replacer/commentReplacer.ts
+++ b/src/replacer/commentReplacer.ts
@@ -33,7 +33,7 @@ export class CommentReplacer {
 
         // 启动新的撒谎会话
         const filePath = editor.document.uri.fsPath;
-        const sessionId = this.historyManager.startLieSession(filePath);
+        const sessionId = this.historyManager.startLieSession(filePath, editor.document.getText());
         console.log(`[CommentReplacer] 开始新的手动替换会话: ${sessionId}`);
 
         try {
@@ -154,7 +154,7 @@ export class CommentReplacer {
 
         // 启动新的撒谎会话
         const filePath = editor.document.uri.fsPath;
-        const sessionId = this.historyManager.startLieSession(filePath);
+        const sessionId = this.historyManager.startLieSession(filePath, editor.document.getText());
         console.log(`[CommentReplacer] 开始新的选中替换会话: ${sessionId}`);
 
         try {
@@ -234,7 +234,7 @@ export class CommentReplacer {
 
         // 启动新的撒谎会话
         const filePath = editor.document.uri.fsPath;
-        const sessionId = this.historyManager.startLieSession(filePath);
+        const sessionId = this.historyManager.startLieSession(filePath, editor.document.getText());
         console.log(`[CommentReplacer] 开始新的智能替换会话: ${sessionId}`);
 
         try {

--- a/src/replacer/dictionaryReplacer.ts
+++ b/src/replacer/dictionaryReplacer.ts
@@ -43,7 +43,7 @@ export class DictionaryReplacer {
 
         // 启动新的撒谎会话
         const filePath = editor.document.uri.fsPath;
-        const sessionId = this.historyManager.startLieSession(filePath);
+        const sessionId = this.historyManager.startLieSession(filePath, editor.document.getText());
         console.log(`[DictionaryReplacer] 开始新的撒谎会话: ${sessionId}`);
 
         // 使用CommentScanner检测当前文件中的所有注释

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export interface HistoryRecord {
     originalText: string;
     newText: string;
     timestamp: number;
-    type: 'manual-replace' | 'dictionary-replace' | 'ai-replace' | 'ai-batch-replace' | 'ai-selective-replace' | 'hide-comment';
+    type: 'manual-replace' | 'dictionary-replace' | 'ai-replace' | 'ai-batch-replace' | 'ai-selective-replace' | 'hide-comment' | 'session-start';
     // 位置信息，使还原更准确
     startPosition: { line: number; character: number };
     endPosition: { line: number; character: number };
@@ -62,6 +62,8 @@ export interface HistoryRecord {
     sessionEndTime?: number;
     // 历史版本号（同一位置的多次修改）
     versionNumber?: number;
+    // 当前文档快照，用于可靠还原
+    fileSnapshot?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- record full document snapshot at session start
- restore comments and toggle state using saved snapshots
- expose `fileSnapshot` field on `HistoryRecord`

## Testing
- `npm test` *(fails: Cannot find module 'vscode' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6847daebb2c08327b39cadd634f90b2e