### PR TITLE
Fix history overflow by clearing old sessions

### DIFF
--- a/src/manager/historyManager.ts
+++ b/src/manager/historyManager.ts
@@ -21,6 +21,9 @@ export class HistoryManager {
     const id = this.generateId();
     this.sessions.set(filePath, id);
 
+    // remove any previous records for this file so only the latest session is kept
+    this.records = this.records.filter(r => r.filePath !== filePath);
+
     // create a snapshot record so we can restore the file later
     const snapshotRecord: HistoryRecord = {
       id: this.generateId(),


### PR DESCRIPTION
## Summary
- clear existing history records whenever a new lie session starts

## Testing
- `npm test` *(fails: Cannot find module 'vscode' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6847dde1c6648327a15b33986a1bf30e